### PR TITLE
New: permit objects to pass straight through

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through2 = require('through2');
-var get = require('lodash.get');
+var _ = require('lodash');
 var xtend = require('xtend');
 var cloneRegExp = require('clone-regexp');
 var leftsplit = require('left-split');
@@ -59,7 +59,6 @@ function ctor(optionsArg, regexArg) {
     if ((typeof output) === 'object') {
       output.line = cursor.line;
       output.column = cursor.column;
-      if (options.source) output.source = options.source;
     }
 
     // Update line & column
@@ -74,7 +73,7 @@ function ctor(optionsArg, regexArg) {
     var output;
     // Allows pseudo-lookbehind by using groups
     // [foo][ ][bar] (true lookbehind would yeild [foo ][bar])
-    var leaveBehind = get(match, options.leaveBehind);
+    var leaveBehind = _.get(match, options.leaveBehind);
 
     if (leaveBehind) {
       output = processOutput(options.separator, [leaveBehind]);
@@ -100,7 +99,7 @@ function ctor(optionsArg, regexArg) {
     var match = null;
     var separator;
 
-    if (chunk) inputBuffer += chunk.toString('utf8');
+    if (chunk) inputBuffer += chunk;
 
     while ((match = pattern.exec(inputBuffer)) !== null) {
       // Content prior to match can be returned without transform
@@ -129,7 +128,12 @@ function ctor(optionsArg, regexArg) {
 
 
   function transform(chunk, encoding, cb) {
-    tokenize.call(this, chunk);
+    // Allow objects straight through. Assumes that input stream is entirely strings or objects.
+    if (!_.isString(chunk) && !_.isBuffer(chunk)) {
+      return cb(null, chunk);
+    }
+
+    tokenize.call(this, chunk.toString('utf8'));
     return cb();
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regexp-stream-tokenizer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A regular expression (RexExp) stream tokenizer.",
   "main": "index.js",
   "scripts": {
@@ -43,7 +43,7 @@
   "dependencies": {
     "clone-regexp": "^1.0.0",
     "left-split": "^1.0.0",
-    "lodash.get": "^4.0.0",
+    "lodash": "^4.0.0",
     "through2": "^2.0.0",
     "xtend": "^4.0.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,24 @@ test.cb('should not return content when no input provided', (t) => {
 });
 
 
+test.cb('should return object chunks unmodified', (t) => {
+  const input = { content: 'The quick brown fox jumps over the lazy dog.' };
+  const stream = tokenizer(/\w+/g);
+
+  stream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      t.deepEqual(chunk, input);
+    }
+  });
+
+  stream.on('end', () => t.end());
+
+  stream.write(input);
+  stream.end();
+});
+
+
 test.cb('should return tokens with default options', (t) => {
   const input = 'The quick brown fox jumps over the lazy dog.';
   const expected = [
@@ -36,7 +54,7 @@ test.cb('should return tokens with default options', (t) => {
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -61,7 +79,7 @@ test.cb('should not return ZBS with default excludeZBS option', (t) => {
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -87,7 +105,7 @@ test.cb('should return ZBS with excludeZBS option false', (t) => {
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -129,7 +147,7 @@ test.cb('should return tokens and separators when separator option true', (t) =>
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -171,7 +189,7 @@ test.cb('should return tokens and separators as objects (string options provided
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -222,7 +240,7 @@ test.cb('should return tokens and separators as objects (function options provid
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -257,7 +275,7 @@ test.cb('should return tokens and separators as objects (function options provid
   words.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });
@@ -297,7 +315,7 @@ test.cb('should tokenize mixed input', (t) => {
   tokenStream.on('readable', function read() {
     let chunk = null;
     while ((chunk = this.read()) !== null) {
-      t.same(chunk, expected[index]);
+      t.deepEqual(chunk, expected[index]);
       index += 1;
     }
   });


### PR DESCRIPTION
Allow objects to be passed straight through. This is helpful for making a generic pipeline which may sometimes receive data that is already tokenised.
